### PR TITLE
Copy data directory during installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include guesslangtools/data/*

--- a/guesslangtools/workflow/compressed_repositories.py
+++ b/guesslangtools/workflow/compressed_repositories.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Dict, Any
-
 import pandas as pd
+from pathlib import Path
 
 from guesslangtools.common import (
     absolute, File, Config, cached, load_csv, download_file, pool_imap
@@ -86,7 +86,7 @@ def download() -> None:
 
     rows = (row_info[1] for row_info in input_data.iterrows())
     result_rows = []
-    for step, row in enumerate(pool_imap(_download_repository, rows), 1):
+    for step, row in enumerate(pool_imap(_download_repository, rows, Config.repositories_dir), 1):
         result_rows.append(row)
         if step % Config.step == 0:
             LOGGER.info('--> Processed %s repositories...', step)
@@ -105,9 +105,10 @@ def download() -> None:
     output_data.to_csv(output_path, index=False)
 
 
-def _download_repository(item: Dict[str, str]) -> Dict[str, str]:
+def _download_repository(item: Dict[str, str], repositories_dir: str) -> Dict[str, str]:
     url = item['repository_url']
-    path = Config.repositories_dir.joinpath(item['repository_filename'])
+    repo_dir = Path(repositories_dir)
+    path = repo_dir.joinpath(item['repository_filename'])
 
     if not path.exists():
         LOGGER.debug('Downloading %s', url)

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=Path('requirements.txt').read_text(),
     zip_safe=True,
+    include_package_data=True,
     # Test
     setup_requires=['pytest-runner'],
     tests_require='pytest',


### PR DESCRIPTION
## Before

`pip install .` does not copy `data` which causes failures when executing

## After

`pip install .` copies `data`

## Context

When trying to set up `guesslangtools` like this

```
$ git clone https://github.com/yoeo/guesslangtools.git
$ cd guesslangtools
$ virtualenv venv
$ source source venv/bin/activate
$ pip install .
```

I ran into the following issue:

```
$ gltool data
Traceback (most recent call last):
  File "-/venv/bin/gltool", line 8, in <module>
    sys.exit(main())
  File "-/venv/lib/python3.8/site-packages/guesslangtools/__main__.py", line 78, in main
    Config.setup(
  File "-/venv/lib/python3.8/site-packages/guesslangtools/common.py", line 82, in setup
    with languages_path.open() as languages_file:
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/pathlib.py", line 1218, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/pathlib.py", line 1074, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '-/venv/lib/python3.8/site-packages/guesslangtools/data/languages.json'
```