### PR TITLE
Copy data directory during installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include guesslangtools/data/*

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=Path('requirements.txt').read_text(),
     zip_safe=True,
+    include_package_data=True,
     # Test
     setup_requires=['pytest-runner'],
     tests_require='pytest',


### PR DESCRIPTION
## Before

`pip install .` does not copy `data` which causes failures when executing

## After

`pip install .` copies `data`

## Context

When trying to set up `guesslangtools` like this

```
$ git clone https://github.com/yoeo/guesslangtools.git
$ cd guesslangtools
$ virtualenv venv
$ source source venv/bin/activate
$ pip install .
```

I ran into the following issue:

```
$ gltool data
Traceback (most recent call last):
  File "-/venv/bin/gltool", line 8, in <module>
    sys.exit(main())
  File "-/venv/lib/python3.8/site-packages/guesslangtools/__main__.py", line 78, in main
    Config.setup(
  File "-/venv/lib/python3.8/site-packages/guesslangtools/common.py", line 82, in setup
    with languages_path.open() as languages_file:
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/pathlib.py", line 1218, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/pathlib.py", line 1074, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '-/venv/lib/python3.8/site-packages/guesslangtools/data/languages.json'
```